### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Reference implementation
 
-This app is baed on the reference implementation of the sample application from
+This app is based on the reference implementation of the sample application from
 [*Ruby on Rails Tutorial:
 Learn Web Development with Rails*](https://www.railstutorial.org/)
 (6th Edition)
@@ -10,7 +10,7 @@ by [Michael Hartl](http://www.michaelhartl.com/).
 
 ## License
 
-All source code in the [ReScript on Rails Tutorial](https://www.railstutorial.org/)
+All source code in the ReScript on Rails Tutorial
 is available jointly under the MIT License and the Beerware License. See
 [LICENSE.md](LICENSE.md) for details.
 


### PR DESCRIPTION
typo: baed => based;
remove the link "ReScript on Rails Tutorial" which leads to Ruby on Rails Tutorial.